### PR TITLE
Jeu de donnée sélectionnable

### DIFF
--- a/visit.json
+++ b/visit.json
@@ -77,7 +77,8 @@
       "attribut_label": "Jeu de données",
       "module_code": "__MODULE.MODULE_CODE",
       "creatable_in_module": "__MODULE.MODULE_CODE.MONITORINGS_VISITES",
-      "required": true
+      "required": true,
+      "value": 37
     },
     "nb_observations": {
       "attribut_label": "Nombre d'observations"
@@ -105,12 +106,6 @@
       "type_widget": "site",
       "required": true,
       "attribut_label": "Choix du site"
-    },
-    "id_dataset": {
-      "type_widget": "text",
-      "attribut_label": "JDD",
-      "value": 37,
-      "hidden": true
     },
     "visit_type": {
       "type_widget": "datalist",


### PR DESCRIPTION
En réponse à une demande des partenaires, validée par les salariés, on permet à l'utilisateur de choisir le JDD à l'échelle de la visite.

Par défaut, c'est le JDD de PicNat qui sera attribué. Si l'utilisateur produit ses données pour le compte d'un partenaire, il pourra les rattacher au JDD  de son organisation. On fait confiance à l'utilisateur pour ne pas faire n'importe quoi (oui oui).

Gestion des JDD saisissable dans la BDD. Actuellement, concerne le CPIE 02 et le PNR OPF. LE CEN dispose également de son JDD, mais ne saisit pas dans la base gîte.